### PR TITLE
Add basic map with covid vaccination sites

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="" />
+  <!-- Make sure you put this AFTER Leaflet's CSS -->
+  <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin=""></script>
+
+  <!-- Load Esri Leaflet from CDN.  it has no .css stylesheet of its own, only .js -->
+  <script src="https://unpkg.com/esri-leaflet@2.5.3/dist/esri-leaflet.js" integrity="sha512-K0Vddb4QdnVOAuPJBHkgrua+/A9Moyv8AQEWi0xndQ+fqbRfAFd47z4A9u1AW/spLO0gEaiE1z98PK1gl5mC5Q==" crossorigin=""></script>
+
   {%- feed_meta -%}
   {%- if site.analytics -%}
     <!-- Matomo -->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,6 +7,19 @@ layout: default
     <h1 class="page-heading">{{ page.title }}</h1>
   {% endif %}
 
+  <div id="mapid" style="height: 500px"></div>
   {{ content }}
 
 </div>
+<script>
+
+//create map with a view of the lower 48 states
+  var mymap = L.map('mapid').setView([39.198, -100.327], 4);
+
+    L.esri.basemapLayer('Streets').addTo(mymap);
+
+    L.esri.featureLayer({
+        url: 'https://services.arcgis.com/8ZpVMShClf8U8dae/arcgis/rest/services/Covid19_Vaccination_Locations/FeatureServer/0'
+      }).addTo(mymap);
+    
+</script>

--- a/index.md
+++ b/index.md
@@ -29,4 +29,6 @@ Alaska
 
 We are entirely volunteer-run and all our code is open source. If you want to help out, shoot us [an email][1]!
 
+want to add your vaccination or testing site? [click here](https://arcg.is/10S1ib)
+
 [1]: mailto:{{site.email}}


### PR DESCRIPTION
data from esri ArcGIS thingy here: https://covid-19-giscorps.hub.arcgis.com/datasets/covid19-vaccination-locations-in-the-united-states?geometry=-16.621%2C-87.862%2C1.660%2C88.858&showData=true

uses leafletjs for the map

tutorial for esri and leaflet stuff here: https://esri.github.io/esri-leaflet/tutorials/create-your-first-app.html


Things to do:

- [ ] style points by status of the vaccination sire, like https://giscorps.maps.arcgis.com/home/webmap/viewer.html?useExisting=1&layers=c50a1a352e944a66aed98e61952051ef does
- [ ] figure out how to allow people to click on the map and see info on that vaccination site (maybe in a new tab?)
- [ ] maybe find a better basemap like topographic or some plain light gray thing like the other maps use? this should be a one line change

